### PR TITLE
feat: Add Netlify configuration and build script for UI deployment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,15 @@
+[build]
+  publish = "ui"
+  command = "bash scripts/build_netlify.sh"
+
+# Set API_BASE_URL in Netlify UI → Site settings → Build & deploy → Environment
+# [build.environment]
+#   API_BASE_URL = "https://<your-render-api>.onrender.com"
+
+# Hash-based router does not need SPA redirects, but keep a safe fallback
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+
+

--- a/scripts/build_netlify.sh
+++ b/scripts/build_netlify.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Replace the ${API_BASE_URL} placeholder in ui/js/api.js with the Netlify env value
+if [[ -z "${API_BASE_URL:-}" ]]; then
+  echo "ERROR: API_BASE_URL env var is required for Netlify build" >&2
+  exit 2
+fi
+
+# Use perl for safe in-place replacement of the literal ${API_BASE_URL}
+perl -0777 -pe "s|\\\$\{API_BASE_URL\}|${API_BASE_URL}|g" -i ui/js/api.js
+
+echo "[netlify] Injected API_BASE_URL=${API_BASE_URL} into ui/js/api.js"
+
+


### PR DESCRIPTION
- Introduced `netlify.toml` for configuring Netlify deployment settings, including build commands and redirects.
- Added `scripts/build_netlify.sh` to replace the `API_BASE_URL` placeholder in the UI code during the build process.
- Updated `README.md` with detailed instructions for deploying the UI on Netlify, including environment variable setup and build commands.